### PR TITLE
Fix the GetProperty function

### DIFF
--- a/object.go
+++ b/object.go
@@ -127,6 +127,11 @@ import (
 	"unsafe"
 )
 
+const (
+	GTypeFundamentalShift = 2
+	GTypeString           = 16
+)
+
 type ObjectCaster interface {
 	AsObject() *Object
 }
@@ -188,6 +193,7 @@ func (o *Object) GetProperty(name string) interface{} {
 	s := C.CString(name)
 	defer C.free(unsafe.Pointer(s))
 	v := new(Value)
+	C.g_value_init(v.g(), GTypeString<<GTypeFundamentalShift)
 	C.g_object_get_property(o.g(), (*C.gchar)(s), v.g())
 	return v.Get()
 }


### PR DESCRIPTION
This PR fixes the GObject GetProperty function by setting a type for the property data to be returned.  This is required before calling the C `g_value_init` function per [the gobject docs](https://developer.gnome.org/gobject/stable/gobject-The-Base-Object-Type.html#g-object-get-property).

For simplicity this just makes everything a string.