### PR TITLE
GetAllPropertyNames Method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 _obj
 _testmain.go
 _go_.6
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/greenkeytech/glib
+
+go 1.13

--- a/object.go
+++ b/object.go
@@ -230,12 +230,12 @@ func (o *Object) GetAllProperties() []ObjectProperty {
 		name := C.GoString(cName)
 		currentValue := o.GetProperty(name)
 
-		var defaultValue Value = C.g_param_spec_get_default_value(paramSpec)
-		
+		cDefaultValue := C.g_param_spec_get_default_value(paramSpec)
+
 		property := ObjectProperty{
 			Name:         name,
 			CurrentValue: currentValue,
-			DefaultValue: defaultValue.Get(),
+			DefaultValue: ValueOf(cDefaultValue).Get(),
 		}
 
 		properties[i] = property

--- a/object.go
+++ b/object.go
@@ -230,7 +230,7 @@ func (o *Object) GetAllProperties() []ObjectProperty {
 		name := C.GoString(cName)
 		currentValue := o.GetProperty(name)
 
-		cDefaultValue := C.g_param_spec_get_default_value(paramSpec)
+		cDefaultValue := *C.g_param_spec_get_default_value(paramSpec)
 
 		property := ObjectProperty{
 			Name:         name,

--- a/object.go
+++ b/object.go
@@ -147,7 +147,6 @@ const (
 
 type ObjectProperty struct {
 	Name string
-	DefaultValue interface{}
 	CurrentValue interface{}
 }
 
@@ -230,12 +229,9 @@ func (o *Object) GetAllProperties() []ObjectProperty {
 		name := C.GoString(cName)
 		currentValue := o.GetProperty(name)
 
-		cDefaultValue := *C.g_param_spec_get_default_value(paramSpec)
-
 		property := ObjectProperty{
 			Name:         name,
 			CurrentValue: currentValue,
-			DefaultValue: ValueOf(cDefaultValue).Get(),
 		}
 
 		properties[i] = property

--- a/object.go
+++ b/object.go
@@ -145,11 +145,6 @@ const (
 	GTypeString           = 16
 )
 
-type ObjectProperty struct {
-	Name string
-	CurrentValue interface{}
-}
-
 type ObjectCaster interface {
 	AsObject() *Object
 }
@@ -216,25 +211,18 @@ func (o *Object) GetProperty(name string) interface{} {
 	return v.Get()
 }
 
-func (o *Object) GetAllProperties() []ObjectProperty {
+func (o *Object) GetAllPropertyNames() []string {
 	gObjectClass := C.get_object_class(o.g())
 	numProperties := C.guint(0)
 	paramSpecs := C.g_object_class_list_properties(gObjectClass, &numProperties)
 	defer C.g_free(C.gpointer(paramSpecs))
-	properties := make([]ObjectProperty, uint(numProperties))
+	properties := make([]string, uint(numProperties))
 
 	for i := 0; i < len(properties); i++ {
 		paramSpec := C.get_param_spec(C.int(i), paramSpecs)
 		cName := C.g_param_spec_get_name(paramSpec)
 		name := C.GoString(cName)
-		currentValue := o.GetProperty(name)
-
-		property := ObjectProperty{
-			Name:         name,
-			CurrentValue: currentValue,
-		}
-
-		properties[i] = property
+		properties[i] = name
 	}
 
 	return properties


### PR DESCRIPTION
This PR adds the GetAllPropertyNames method so that, for a given GObject, we can retrieve the names of its defined parameters.